### PR TITLE
use `buffer` instead of `native-buffer-browserify`

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -4,7 +4,7 @@ var exports = module.exports = function (alg) {
   return new Alg()
 }
 
-var Buffer = require('native-buffer-browserify').Buffer
+var Buffer = require('buffer/').Buffer
 var Hash   = require('./hash')(Buffer)
 
 exports.sha =

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/dominictarr/sha.js.git"
   },
   "dependencies": {
-    "native-buffer-browserify": "~2.0.8"
+    "buffer": "~2.1.12"
   },
   "devDependencies": {
     "tape": "~2.3.2"

--- a/test/hash.js
+++ b/test/hash.js
@@ -1,7 +1,7 @@
 var hexpp = require('../hexpp').defaults({bigendian: false})
 var u = require('../util')
 var tape = require('tape')
-var Buffer = require('native-buffer-browserify').Buffer
+var Buffer = require('buffer/').Buffer
 var Hash = require('../hash')(Buffer)
 
 var hex = '0A1B2C3D4E5F6G7H', hexbuf


### PR DESCRIPTION
The module has been renamed and all the latest fixes are going into `buffer`. :)
