### PR TITLE
Fixes disparity between 'SHA1' working on node but failing in browser

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -1,5 +1,5 @@
 var exports = module.exports = function (alg) {
-  var Alg = exports[alg]
+  var Alg = exports[alg.toLowerCase()]
   if(!Alg) throw new Error(alg + ' is not supported (we accept pull requests)')
   return new Alg()
 }


### PR DESCRIPTION
Example scenario:
- Passing `SHA1` instead of `sha1` to `createHmac` passed on `node` but threw on browser. 

This fixes that.
