### PR TITLE
Fix streaming updates (limit writing so it doesn't go over block size)

### DIFF
--- a/hash.js
+++ b/hash.js
@@ -50,7 +50,7 @@ module.exports = function (Buffer) {
     var f = 0
     var buffer = this._block
     while(s < l) {
-      var t = Math.min(length, f + bl)
+      var t = Math.min(length, f + bl - s%bl)
       write(buffer, data, enc, s%bl, f, t)
       var ch = (t - f);
       s += ch; f += ch


### PR DESCRIPTION
`test/vectors.js` now passes (as does the example I had problems with in https://github.com/dominictarr/crypto-browserify/issues/9)
