### PR TITLE
add install instructions for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Streamable SHA hashes in pure javascript.
 
 [![testling badge](https://ci.testling.com/dominictarr/sha.js.png)](https://ci.testling.com/dominictarr/sha.js)
 
+## Installing with [NPM](https://npmjs.org/ "NPM")
+
+```
+$ npm install sha.js
+```
+
 ## Example
 
 ``` js


### PR DESCRIPTION
Users might confuse sha.js with sha (see #27). Install instructions should
prevent further confusions.

closes #28