### PR TITLE
Fix digesting of large data (more than MAX_UINT32 bits)

### DIFF
--- a/hash.js
+++ b/hash.js
@@ -54,8 +54,13 @@ Hash.prototype.digest = function (enc) {
   }
 
   // to this append the block which is equal to the number l written in binary
-  // TODO: handle case where l is > Math.pow(2, 29)
-  this._block.writeInt32BE(l, this._blockSize - 4)
+  if (l <= 0xffffffff) {
+    this._block.writeUInt32BE(l, this._blockSize - 4)
+  } else {
+    var ll = l & 0xffffffff
+    this._block.writeUInt32BE((l - ll) / 0x100000000, this._blockSize - 8)
+    this._block.writeUInt32BE(ll, this._blockSize - 4)
+  }
 
   var hash = this._update(this._block) || this._hash()
 

--- a/test/test.js
+++ b/test/test.js
@@ -83,3 +83,18 @@ tape('hex encoding', function (t) {
 
   t.end()
 })
+
+tape('call digest for more than MAX_UINT32 bits of data', function (t) {
+  var _hash = crypto.createHash('sha1')
+  var hash = new Sha1()
+  var bigData = new Buffer(Math.pow(2, 32) / 8)
+
+  hash.update(bigData)
+  _hash.update(bigData)
+
+  var a = hash.digest('hex')
+  var e = _hash.digest('hex')
+
+  t.equal(a, e)
+  t.end()
+})


### PR DESCRIPTION
This is based on @samKamerer's work in PR #39, with the following additions: 

* rebased to the current master
* uses constants instead of calling `Math.pow(2, 32)` in `digest()`
* uses exactly 2^32 bits in the test (the smallest failing amount)

Sorry for opening another PR for this, but I didn't know how to do it otherwise.