### PR TITLE
drop Node <4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,15 @@ os:
   - linux
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
   - "4"
   - "5"
   - "6"
+  - "7"
 env:
   matrix:
     - TEST_SUITE=unit
 matrix:
   include:
-    - node_js: "4"
+    - node_js: "7"
       env: TEST_SUITE=lint
 script: npm run $TEST_SUITE


### PR DESCRIPTION
Resolves the test failures,  as even `safe-buffer` doesn't handle <4 (afaik)