### PR TITLE
Change "new shajs.SHA256()" to lowercase to make it actually work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ var shajs = require('sha.js')
 
 console.log(shajs('sha256').update('42').digest('hex'))
 // => 73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049
-console.log(new shajs.SHA256().update('42').digest('hex'))
+console.log(new shajs.sha256().update('42').digest('hex'))
 // => 73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049
 
 var sha256stream = shajs('sha256')


### PR DESCRIPTION
Fix issue in usage example