### PR TITLE
convert lowBits to unsigned in hash.js

### DIFF
--- a/hash.js
+++ b/hash.js
@@ -61,7 +61,7 @@ Hash.prototype.digest = function (enc) {
 
   // uint64
   } else {
-    var lowBits = bits & 0xffffffff
+    var lowBits = (bits & 0xffffffff) >>> 0
     var highBits = (bits - lowBits) / 0x100000000
 
     this._block.writeUInt32BE(highBits, this._blockSize - 8)


### PR DESCRIPTION
For file sizes (in bits) greater than uint32, lowBits is signed, which results in wrong calculation for values with most significant bit of the variable lowBits as 1.

Example: bits=8195670016 
then lowBits = bits & 0xffffffff = -394264576
