### PR TITLE
Project is bound by MIT AND BSD-3-Clause licenses.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,49 @@
-Copyright (c) 2013-2014 sha.js contributors
+Copyright (c) 2013-2018 sha.js contributors
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
-subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice 
-shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Copyright (c) 1998 - 2009, Paul Johnston & Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the author nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "unit": "set -e; for t in test/*.js; do node $t; done;"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
-  "license": "MIT"
+  "license": "(MIT AND BSD-3-Clause)"
 }


### PR DESCRIPTION
Closes #42.

## MIT _AND_ BSD-3-Clause

I noticed there's quite a bit of confusion in #42, in particular with the suggestion that this project migrate to BSD-3-Clause. That's possible, but a serious pain, as to do so legally [you need consent of every contributor who contributed](https://opensource.guide/legal/#what-if-i-want-to-change-the-license-of-my-project) whilst they thought the project was MIT licensed.

However, as @bastien-roucaries rightly pointed out, this project's origins are BSD-3-Clause, not MIT.

The correct licensing for this project is BOTH MIT *and* BSD-3-Clause. This is *not* a dual-licensing arrangement, it's a __conjunctive "AND"__ i.e. the project is bound by both licenses simultaneously.

Luckily this is perfectly acceptable as the licenses are compatible. Even better, this is officially [supported by NPM](https://docs.npmjs.com/files/package.json#license), which itself supports the SPDX specification, see [Appendix IV:  SPDX License Expressions](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) (subsection `2) Conjunctive "AND" Operator`).

[Paul Johnston's original license](http://pajhome.org.uk/site/legal.html#bsdlicense) is the BSD-3-Clause license, albeit not expressed precisely in its most common form. Note the use of the word "author" instead of "the copyright holder" in clause 3. This is not entirely unheard of, and is perfectly compatible with the SPDX's definition of [BSD 3 clause](https://spdx.org/licenses/BSD-3-Clause.html) (sections in red are not required verbatim).

As such, I've updated the `LICENSE` file to include a verbatim copy of _both_ licenses, sha.js' MIT followed by Paul Johnston's BSD.

## Formatting of LICENSE

Although the wording is verbatim, the formatting (whitespace) has been modified. This is perfectly acceptable and does not at all change the legal meaning of the licenses or violate either license.

In the case of Paul Johnston's license, a line break was included to seperate Clause 1 and Clause 2 of the BSD-3-Clause license, as in its original form they were included on the one line.

The MIT license was wrapped to 78 characters wide to match [common formatting, seen on Wikipedia](https://en.wikipedia.org/wiki/MIT_License#License_terms).

The BSD-3-Clause was wrapped to 79 characters, to more closely match [common formatting, seen on Wikipedia](https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_("BSD_License_2.0",_"Revised_BSD_License",_"New_BSD_License",_or_"Modified_BSD_License")). However, the formatting is _not_ identical to that seen on Wikipedia (or commonly seen elsewhere) as the clause list typically includes numbers or list bullets. These are optional (highlighted red) in the SPDX BSD-3-Clause specification.

Although they're common, I did not opt to add bullets or numbers to the clause list. As whilst I _believe_ it to be legally sound (IANAL), I did not want to introduce even a shred of doubt when it comes to honouring the BSD's first license clause:

> Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

## NPM

I've also updated `package.json` to include the aforementioned SPDX license expression:

> (MIT AND BSD-3-Clause)