### PR TITLE
Prevent test failure on 32-bit architectures

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -87,7 +87,7 @@ tape('hex encoding', function (t) {
 tape('call digest for more than MAX_UINT32 bits of data', function (t) {
   var _hash = crypto.createHash('sha1')
   var hash = new Sha1()
-  var bigData = Buffer.alloc(0x1ffffffff / 8)
+  var bigData = Buffer.alloc(0x1fffffff8 / 8)
 
   hash.update(bigData)
   _hash.update(bigData)


### PR DESCRIPTION
RangeError: "size" argument must not be larger than 1073741823
This test worked previously in version 2.4.9.