### PR TITLE
Fix npmignore to exclude test directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 tests/
+test/
+npm-debug.log
+.travis.yml


### PR DESCRIPTION
Hello!

I've found that you have `tests/` excluded in `.npmignore` file, while [npm package indeed contains](https://zitros.github.io/npm-explorer/?p=sha.js) `test/` and `.travis.yml` files. This pull request fixes npm bundle.

Thanks!