### PR TITLE
fix: yarn warning for invalid bin entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "tape": "~2.3.2",
     "typedarray": "0.0.6"
   },
-  "bin": "./bin.js",
+  "bin": {
+    "shajs": "./bin.js"
+  },
   "scripts": {
     "prepublish": "npm ls && npm run unit",
     "lint": "standard",


### PR DESCRIPTION
BREAKING CHANGE: 
Removed the dot in the binary name.
```diff
- $ sha.js
+ $ shajs
```

Closes #64

Can be verified locally. A `yarn` in the source directory will not warn about invalid bin entries on this branch.

