### PR TITLE
docs: describe parameter types & instruct TS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ console.log(sha256stream.read().toString('hex'))
 Note, this doesn't actually implement a stream, but wrapping this in a stream is trivial.
 It does update incrementally, so you can hash things larger than RAM, as it uses a constant amount of memory (except when using base64 or utf8 encoding, see code comments).
 
+## TypeScript
+
+Library can be used with types, use [`npm i @types/sha.js`](https://www.npmjs.com/package/@types/sha.js) and add `sha.js` under `types` in your `tsconfig.json`. Expected type-checking can be illustrated as follows:
+```ts
+return sha(algorithm as 'sha' | 'sha1' | 'sha224' | 'sha256' | 'sha384' | 'sha512')
+      .update(data as string | NodeJS.ArrayBufferView)
+      .digest(encoding as 'latin1' | 'hex' | 'base64')
+```
 
 ## Acknowledgements
 This work is derived from Paul Johnston's [A JavaScript implementation of the Secure Hash Algorithm](http://pajhome.org.uk/crypt/md5/sha1.html).


### PR DESCRIPTION
When I was reading current README in a hurry, I felt like the current instructions are ambiguous, e.g. as if the `'42'` parameter is some length and `'hex'` is a value to be converted. The list of supported algorithms also has to be deduced with some assumptions. My suggestion is to solve all these issues together by explicitly documenting the type of this library interface for any newcomers, possibly along with a reminder that the `@types/sha.js` library is also available (it feels like the "on pure JavaScript" description implies otherwise).

The `algorithm` parameter is however typed as `string` right now; I've prepared a PR to address this in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59757