### PR TITLE
support multi-byte wide typed arrays

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,5 +60,17 @@
 				"max-lines-per-function": "off",
 			},
 		},
+		{
+			"files": "hash.js",
+			"globals": {
+				"Uint8Array": false,
+			},
+		},
+		{
+			"files": "test/test.js",
+			"globals": {
+				"Uint16Array": false,
+			},
+		},
 	],
 }

--- a/hash.js
+++ b/hash.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Buffer = require('safe-buffer').Buffer;
+var toBuffer = require('to-buffer');
 
 // prototype class for hash functions
 function Hash(blockSize, finalSize) {
@@ -12,10 +13,7 @@ function Hash(blockSize, finalSize) {
 
 Hash.prototype.update = function (data, enc) {
 	/* eslint no-param-reassign: 0 */
-	if (typeof data === 'string') {
-		enc = enc || 'utf8';
-		data = Buffer.from(data, enc);
-	}
+	data = toBuffer(data, enc || 'utf8');
 
 	var block = this._block;
 	var blockSize = this._blockSize;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "inherits": "^2.0.4",
-    "safe-buffer": "^5.2.1"
+    "safe-buffer": "^5.2.1",
+    "to-buffer": "^1.2.0"
   },
   "devDependencies": {
     "@ljharb/eslint-config": "^21.1.1",


### PR DESCRIPTION
Same as: https://github.com/browserify/hash-base/pull/19, https://github.com/browserify/cipher-base/pull/23, but retains support for Array and Array-like objects, since this module isn't closely mimicking the Node.js API

For array-likes, coherence rechecks are added to ensure invalid results are not returned

On everything Node.js createHash works, this now should be compatible + additionally keeps array-like support